### PR TITLE
allow p12 creation without cacert; timelimit openssl exec

### DIFF
--- a/main.go
+++ b/main.go
@@ -207,6 +207,9 @@ func generateCertificate() {
 	}
 
 	log.Printf("certificate key pair created: cert: %s-cert.pem, key: %s-key.pem", viper.GetString("name"), viper.GetString("name"))
+	if viper.GetBool("p12") {
+		log.Printf("p12 bundle created: %s.p12", viper.GetString("name"))
+	}
 }
 
 func generateCSR() {


### PR DESCRIPTION
## Description

- fixes a hard to debug error when creating a PKCS12 certificate .p12 file, and the exec of `openssl` fails for some reason. 
- the actual reason for the failure was trying to create a PCKS12 self-signed certificate (which, by definition, has no CA certificate) 

When trying to create a self-signed certificate , and bundling the private key and the certificate into a PKCS12 file, it will fail as follows, because there is no CA used for signing.  This is not an error, and it's perfectly legal to create self-signed PKCS12 bundle. 

```
$ tg cert --name mycert --p12 --p12-pass foo --ip 192.168.10.10 --common-name "bonn@paloaltonetworks.com"
2024/12/06 14:13:25 could not generate certificate: unable to write p12 on file: exit status 1
```
There is no indication why it failed.  It's actually the exec of `openssl` that fails due to bad arguments (see below)

If we create a CA first, then use that CA, the PKCS12 certificate generation works, and it embeds the CA certificate into the PKCS12 file too.  But this is not the desired result, since we only want a self-signed certificate and private key in the PKCS12 file, and there is no CA for a self-signed certificate. 

An example below, showing how we can create and use the CA certificate: 
```
$ tg cert --name myca --org acme --common-name root --is-ca --pass secret
2024/12/06 14:17:11 certificate key pair created: cert: myca-cert.pem, key: myca-key.pem

$ tg cert --name mycert --p12 --p12-pass foo --ip 192.168.10.10 --common-name "bonn@paloaltonetworks.com"  \
   --signing-cert myca-cert.pem  \
   --signing-cert-key myca-key.pem \
   --signing-cert-key-pass secret
2024/12/06 14:19:54 certificate key pair created: cert: mycert-cert.pem, key: mycert-key.pem

$ ls -l *.p12
-rw------- 1 bonn staff 1488 Dec  6 14:19 mycert.p12
```

The root cause is how the command line is built, it always provides the  CA file as an option to `openssl` even if it's an empty string (not set on the `tg` command line) and this empty string for the CA file causes the `openssl` command to fail. 

This code change also includes a timeout for the execution of `openssl` to limit it to 60 seconds max before it will be killed and fail.  This bounds the execution environment to prevent hangs while the code is waiting for `openssl` to finish. 

After this PR is merged the PKCS12 self-signed certificate can now be created:
```
$ tg cert --name mycert --p12 --p12-pass foo --ip 192.168.10.10 --common-name "bonn@paloaltonetworks.com"
2024/12/06 14:46:49 certificate key pair created: cert: mycert-cert.pem, key: mycert-key.pem
2024/12/06 14:46:49 p12 bundle created: mycert.p12
```

## Motivation and Context

Fixes an issue that prevents you from creating a self-signed PKCS12 file. 

## How Has This Been Tested?

- Tested locally. 
- verified with `openssl pkcs12 info` 

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
